### PR TITLE
fetch-configlet: Use `jq`; add `-Sf` curl flags; specify API version

### DIFF
--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -4,7 +4,7 @@ get_download_url() {
   # Returns the download URL of the latest configlet Linux release from the GitHub API
   local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'
   local asset_name='configlet-linux-64bit.tgz'
-  curl -sSf "${api_url}" |
+  curl -H "Accept: application/vnd.github.v3+json" -sSf "${api_url}" |
     jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 

--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -1,13 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+curlopts=(
+  --silent
+  --show-error
+  --fail
+)
+
 get_download_url() {
   # Returns the download URL of the latest configlet Linux release from the GitHub API
   local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'
   local asset_name='configlet-linux-64bit.tgz'
-  curl -H "Accept: application/vnd.github.v3+json" -sSf "${api_url}" |
+  curl "${curlopts[@]}" --header "Accept: application/vnd.github.v3+json" "${api_url}" |
     jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 
 download_url="$(get_download_url)"
-curl -sSfL "${download_url}" | tar xz -C bin/
+curl "${curlopts[@]}" --location "${download_url}" | tar xz -C bin/

--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
-get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-    grep '"tag_name":' |                                            # Get tag line
-    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+get_download_url() {
+  # Returns the download URL of the latest configlet Linux release from the GitHub API
+  local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'
+  local asset_name='configlet-linux-64bit.tgz'
+  curl -s "${api_url}" |
+    jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 
-URL="https://github.com/exercism/configlet/releases/download/$(get_latest_release "exercism/configlet")/configlet-linux-64bit.tgz"
-
-curl -s --location "$URL" | tar xz -C bin/
+download_url="$(get_download_url)"
+curl -sL "${download_url}" | tar xz -C bin/

--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -4,9 +4,9 @@ get_download_url() {
   # Returns the download URL of the latest configlet Linux release from the GitHub API
   local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'
   local asset_name='configlet-linux-64bit.tgz'
-  curl -s "${api_url}" |
+  curl -sSf "${api_url}" |
     jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 
 download_url="$(get_download_url)"
-curl -sL "${download_url}" | tar xz -C bin/
+curl -sSfL "${download_url}" | tar xz -C bin/

--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 get_download_url() {
   # Returns the download URL of the latest configlet Linux release from the GitHub API


### PR DESCRIPTION
This PR attempts to improve the `configlet` action's `fetch-configlet` script.

I'd appreciate feedback from any of the 60 (!) people that watch this repo. I intend to add these changes (without the change to use `jq`) to the non-CI versions of the fetch scripts.

The commit messages are reproduced below.

---

fetch-configlet: Use `jq`

We know that `jq` is always installed in the environment where this
script is used. So let's use `jq`.

Advantages:
- Parsing the JSON is more robust than using `grep` and `sed`.
- It makes it easier to use the download URL that the API returns,
  rather than constructing that URL ourselves from the tag.

---

fetch-configlet: Add `-Sf` flags to curl

Summary:
- Add the `-S, --show-error` flag. When combined with the existing
  `-s, --silent` flag, this hides curl's progress meter without hiding
  error messages.
- Add the `-f, --fail` flag. This helps to stop curl from piping
  non-useful output into `jq` or `tar` in the case of failure.

See:
- https://curl.se/docs/manpage.html#-S
- https://curl.se/docs/manpage.html#-f

---

fetch-configlet: Request a specific GitHub API version

The commit adds a header to our API request.

From the GitHub Docs:
> Important: The default version of the API may change in the future. If
> you're building an application and care about the stability of the
> API, be sure to request a specific version in the Accept header

See:
- https://docs.github.com/en/free-pro-team@latest/rest/overview/media-types
- https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-a-release

---

fetch-configlet: Add `set -euo pipefail`

GitHub Actions already sets `-eo pipefail` by default, so this really
only adds `-u`.

However, it's still nice to write this explicitly because:
- It helps the reader who doesn't know or remember that GitHub Actions
  sets `-eo pipefail` by default.
- Some maintainers who use Linux and have `jq` installed might prefer to
  use