### PR TITLE
fetch-canonical_data_syncer: Improve and pin version to v0.17.0

### DIFF
--- a/canonical-data-syncer-ci/fetch-canonical_data_syncer
+++ b/canonical-data-syncer-ci/fetch-canonical_data_syncer
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 curlopts=(
   --silent

--- a/canonical-data-syncer-ci/fetch-canonical_data_syncer
+++ b/canonical-data-syncer-ci/fetch-canonical_data_syncer
@@ -4,13 +4,13 @@ curlopts=(
   --silent
 )
 
-# https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
-get_latest_release() {
-  curl "${curlopts[@]}" "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-    grep '"tag_name":' |                                            # Get tag line
-    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+get_download_url() {
+  # Returns the download URL of the latest Linux release from the GitHub API
+  local api_url='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
+  local asset_name='canonical_data_syncer-linux-64bit.tgz'
+  curl "${curlopts[@]}" "${api_url}" |
+    jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 
-URL="https://github.com/exercism/canonical-data-syncer/releases/download/$(get_latest_release "exercism/canonical-data-syncer")/canonical_data_syncer-linux-64bit.tgz"
-
-curl "${curlopts[@]}" --location "$URL" | tar xz -C bin/
+download_url="$(get_download_url)"
+curl "${curlopts[@]}" --location "${download_url}" | tar xz -C bin/

--- a/canonical-data-syncer-ci/fetch-canonical_data_syncer
+++ b/canonical-data-syncer-ci/fetch-canonical_data_syncer
@@ -5,15 +5,16 @@ curlopts=(
   --silent
   --show-error
   --fail
+  --location
 )
 
 get_download_url() {
-  # Returns the download URL of the latest Linux release from the GitHub API
-  local api_url='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
+  # Returns the download URL of the v0.17.0 Linux release from the GitHub API
+  local api_url='https://api.github.com/repos/exercism/canonical-data-syncer/releases/33439231'
   local asset_name='canonical_data_syncer-linux-64bit.tgz'
   curl "${curlopts[@]}" --header "Accept: application/vnd.github.v3+json" "${api_url}" |
     jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 
 download_url="$(get_download_url)"
-curl "${curlopts[@]}" --location "${download_url}" | tar xz -C bin/
+curl "${curlopts[@]}" "${download_url}" | tar xz -C bin/

--- a/canonical-data-syncer-ci/fetch-canonical_data_syncer
+++ b/canonical-data-syncer-ci/fetch-canonical_data_syncer
@@ -10,7 +10,7 @@ get_download_url() {
   # Returns the download URL of the latest Linux release from the GitHub API
   local api_url='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
   local asset_name='canonical_data_syncer-linux-64bit.tgz'
-  curl "${curlopts[@]}" "${api_url}" |
+  curl "${curlopts[@]}" --header "Accept: application/vnd.github.v3+json" "${api_url}" |
     jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 

--- a/canonical-data-syncer-ci/fetch-canonical_data_syncer
+++ b/canonical-data-syncer-ci/fetch-canonical_data_syncer
@@ -2,6 +2,8 @@
 
 curlopts=(
   --silent
+  --show-error
+  --fail
 )
 
 get_download_url() {

--- a/canonical-data-syncer-ci/fetch-canonical_data_syncer
+++ b/canonical-data-syncer-ci/fetch-canonical_data_syncer
@@ -1,12 +1,16 @@
 #!/bin/bash
 
+curlopts=(
+  --silent
+)
+
 # https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
 get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+  curl "${curlopts[@]}" "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
     grep '"tag_name":' |                                            # Get tag line
     sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
 }
 
 URL="https://github.com/exercism/canonical-data-syncer/releases/download/$(get_latest_release "exercism/canonical-data-syncer")/canonical_data_syncer-linux-64bit.tgz"
 
-curl -s --location "$URL" | tar xz -C bin/
+curl "${curlopts[@]}" --location "$URL" | tar xz -C bin/


### PR DESCRIPTION
This PR makes the same changes to `fetch-canonical_data_syncer` that https://github.com/exercism/github-actions/pull/9 made to `fetch-configlet`, but with an extra commit that pins the version.

The commits are atomic - please review individually.

The `diff` between this repo's `fetch-configlet` script and this PR's `fetch-canonical_data_syncer` script is:
```diff
--- configlet-ci/fetch-configlet
+++ canonical-data-syncer-ci/fetch-canonical_data_syncer 
 #!/bin/bash
 set -euo pipefail

 curlopts=(
   --silent
   --show-error
   --fail
+  --location
 )
 
 get_download_url() {
-  # Returns the download URL of the latest configlet Linux release from the GitHub API
-  local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'
-  local asset_name='configlet-linux-64bit.tgz'
+  # Returns the download URL of the v0.17.0 Linux release from the GitHub API
+  local api_url='https://api.github.com/repos/exercism/canonical-data-syncer/releases/33439231'
+  local asset_name='canonical_data_syncer-linux-64bit.tgz'
   curl "${curlopts[@]}" --header "Accept: application/vnd.github.v3+json" "${api_url}" |
     jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
 }
 
 download_url="$(get_download_url)"
-curl "${curlopts[@]}" --location "${download_url}" | tar xz -C bin/
+curl "${curlopts[@]}" "${download_url}" | tar xz -C bin/
```