### PR TITLE
fetch-configlet: Follow redirects in API request

### DIFF
--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -5,6 +5,7 @@ curlopts=(
   --silent
   --show-error
   --fail
+  --location
 )
 
 get_download_url() {
@@ -16,4 +17,4 @@ get_download_url() {
 }
 
 download_url="$(get_download_url)"
-curl "${curlopts[@]}" --location "${download_url}" | tar xz -C bin/
+curl "${curlopts[@]}" "${download_url}" | tar xz -C bin/


### PR DESCRIPTION
From the docs[1]:
> API v3 uses HTTP redirection where appropriate. Clients should assume
> that any request may result in a redirection. Receiving an HTTP
> redirection is not an error and clients should follow that redirect.

[1] https://docs.github.com/en/rest/overview/resources-in-the-rest-api#http-redirects