### PR TITLE
fetch-configlet: Add retry to curl options

### DIFF
--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -6,6 +6,7 @@ curlopts=(
   --show-error
   --fail
   --location
+  --retry 3
 )
 
 get_download_url() {


### PR DESCRIPTION
Our curl commands will now retry a failed request up to 3 times.

From the docs for `--retry`:
> If a transient error is returned when curl tries to perform a
> transfer, it will retry this number of times before giving up. Setting
> the number to 0 makes curl do no retries (which is the default).
> Transient error means either: a timeout, an FTP 4xx response code or
> an HTTP 408, 429 or 5xx response code.

> When curl is about to retry a transfer, it will first wait one second
> and then for all forthcoming retries it will double the waiting time
> until it reaches 10 minutes which then will be the delay between the
> rest of the retries.

See:
- https://curl.se/docs/manpage.html#--retry