### PR TITLE
configlet-ci: Output the configlet version

### DIFF
--- a/configlet-ci/action.yml
+++ b/configlet-ci/action.yml
@@ -16,3 +16,5 @@ runs:
     shell: bash
   - run: echo "$PWD/bin" >> $GITHUB_PATH
     shell: bash
+  - run: echo "configlet version $(bin/configlet --version)"
+    shell: bash


### PR DESCRIPTION
Does this work?

---

This tries to make it easier for a user to determine the version of
configlet that ran during CI.

This could be helpful as more linting rules are added - users might
want to re-run their configlet workflow if configlet was updated.