### PR TITLE
configlet-ci: Check JSON files are valid

### DIFF
--- a/configlet-ci/action.yml
+++ b/configlet-ci/action.yml
@@ -4,7 +4,7 @@ author: 'Sascha Mann'
 branding:
   icon: 'download'
   color: 'purple'
-  
+
 runs:
   using: "composite"
   steps:
@@ -17,4 +17,6 @@ runs:
   - run: echo "$PWD/bin" >> $GITHUB_PATH
     shell: bash
   - run: echo "configlet version $(bin/configlet --version)"
+    shell: bash
+  - run: find . -type f -name '*.json' -printf '%f\n' -exec jq empty {} +;
     shell: bash


### PR DESCRIPTION
See https://github.com/exercism/wren/pull/26#pullrequestreview-674121102

To-do:
- [ ] Print the path to the file with an error
- [ ] Add the check in a separate job?
- [ ] Find a way to produce an error for a duplicate key?

Note that this does not currently produce an error for a duplicate key. But it does for:
- a comment with `#`
- a trailing comma