### PR TITLE
Add configlet reusable workflow

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -1,0 +1,36 @@
+name: Configlet
+
+on:
+  workflow_call:
+    inputs:
+      lint:
+        description: "Run configlet lint"
+        default: true
+        required: false
+        type: boolean
+      fmt:
+        description: "Run configlet fmt"
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  configlet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+
+      - name: Fetch configlet
+        uses: exercism/github-actions/configlet-ci@main
+
+      - name: Run configlet lint
+        run: configlet lint
+        if: ${{inputs.lint}}
+
+      - name: Run configlet fmt
+        run: configlet fmt
+        if: ${{inputs.fmt}}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,72 @@
 # Exercism's GitHub Actions
 
 A collection of custom GitHub actions used throughout Exercism.
+
+## Reusable workflow: configlet
+
+The `configlet` reusable workflow can be used to easily run [configlet][configlet] commands.
+Currently, two commands are supported:
+
+- `configlet lint`: check if a track's configuration files are properly structured (see [the docs][configlet-lint])
+- `configlet fmt`: check if the track's files are properly formatted
+
+### Inputs
+
+The commands can be enabled or disabled via two boolean inputs:
+
+| Name   | Description          | Type      | Required | Default |
+| ------ | -------------------- | --------- | -------- | ------- |
+| `lint` | Run `configlet lint` | `boolean` | No       | `true`  |
+| `fmt`  | Run `configlet fmt`  | `boolean` | No       | `false` |
+
+### Example: default (only linting)
+
+```yaml
+name: Configlet
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  configlet:
+    uses: exercism/github-actions/.github/workflows/configlet.yml@main
+```
+
+Note that the worklow will take care of everything, including checking out the code.
+
+### Example: run linting and formatting
+
+```yaml
+name: Configlet
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  configlet:
+    uses: exercism/github-actions/.github/workflows/configlet.yml@main
+    with:
+      fmt: true
+```
+
+### Example: only formatting
+
+```yaml
+name: Configlet
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  configlet:
+    uses: exercism/github-actions/.github/workflows/configlet.yml@main
+    with:
+      lint: false
+      fmt: true
+```
+
+[configlet]: https://exercism.org/docs/building/configlet
+[configlet-lint]: https://exercism.org/docs/building/configlet/lint


### PR DESCRIPTION
This PRs adds a reusable `configlet` workflow, which simplifies (and makes consistent) the configlet workflow used in the tracks.

The reusable configlet work allows for two commands to be run:

1. `configlet lint`: enabled by default
2. `configlet fmt`: disabled by default

Once this PR is merged, we can then send bulk PRs to all tracks to update their configlet workflow to use this reusable workflow.
The best way to do this is to use the `org-wide-files` syncing.
If tracks want to opt into running `configlet fmt`, they can do so via the `fmt` input.

An additional benefit of using a reusable workflow is to greatly cut down on the number of dependabot PRs being created.
Currently, the configlet workflow used in tracks all receive dependabot updates, but once we've migrated to a workflow that uses this reusable workflow, we only have to update these dependencies here.

edit: this will be the `org-wide-files` file: https://github.com/exercism/org-wide-files/pull/10/files

---

I've created a sample PR to show what using this reusable workflow would look like: https://github.com/exercism/csharp/pull/1884