### PR TITLE
Add docker-build-push-image reusable workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,112 @@
+name: Build and Push Docker image
+
+on:
+  workflow_call:
+    inputs:
+      aws_ecr:
+        description: "Push to AWS ECR"
+        default: true
+        required: false
+        type: boolean
+      docker_hub:
+        description: "Push to Docker Hub"
+        default: true
+        required: false
+        type: boolean
+    secrets:
+      AWS_ACCOUNT_ID:
+        description: "The AWS account ID used to determine the ECR registry"
+        required: true
+        type: string
+      AWS_REGION:
+        description: "The AWS region used to determine the ECR registry"
+        required: true
+        type: string
+      AWS_ECR_ACCESS_KEY_ID:
+        description: "The access key ID used to log into AWS ECR"
+        required: true
+        type: string
+      AWS_ECR_SECRET_ACCESS_KEY:
+        description: "The secret access key ID used to log into AWS ECR"
+        required: true
+        type: string
+      DOCKERHUB_USERNAME:
+        description: "The username used to log into Docker Hub"
+        required: true
+        type: string
+      DOCKERHUB_PASSWORD:
+        description: "The password used to log into Docker Hub"
+        required: true
+        type: string
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    env:
+      ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+
+      - name: Cache Docker layers
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: ${{inputs.docker_hub}}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Login to ECR
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: ${{inputs.aws_ecr}}
+        with:
+          registry: ${{ env.ECR_REGISTRY }}
+          username: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        if: ${{inputs.docker_hub}}
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ github.event.repository.full_name }}:latest
+            ${{ github.event.repository.full_name }}:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Push to AWS ECR
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        if: ${{inputs.aws_ecr}}
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:production
+            ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -39,6 +39,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -68,5 +68,35 @@ jobs:
       fmt: true
 ```
 
+## Reusable workflow: docker-build-push-image
+
+The `docker-build-push-image` reusable workflow can be used to easily build and push a repository's Docker image to AWS ECR and/or Docker Hub.
+
+### Inputs
+
+Which registry you want the built image to be pushed to can be enabled or disabled via two boolean inputs:
+
+| Name         | Description        | Type      | Required | Default |
+| ------------ | ------------------ | --------- | -------- | ------- |
+| `aws_ecr`    | Push to AWS ECR    | `boolean` | False    | `true`  |
+| `docker_hub` | Push to Docker Hub | `boolean` | False    | `true`  |
+
+### Secrets
+
+Which registry you want the built image to be pushed to can be enabled or disabled via two boolean inputs:
+
+| Name                        | Description                                           | Type     | Required |
+| --------------------------- | ----------------------------------------------------- | -------- | -------- |
+| `AWS_ACCOUNT_ID`            | The AWS account ID used to determine the ECR registry | `string` | Yes      |
+| `AWS_REGION`                | The AWS region used to determine the ECR registry     | `string` | Yes      |
+| `AWS_ECR_ACCESS_KEY_ID`     | The access key ID used to log into AWS ECR            | `string` | Yes      |
+| `AWS_ECR_SECRET_ACCESS_KEY` | The secret access key ID used to log into AWS ECR     | `string` | Yes      |
+| `DOCKERHUB_USERNAME`        | The username used to log into Docker Hub              | `string` | Yes      |
+| `DOCKERHUB_PASSWORD`        | The password used to log into Docker Hub              | `string` | Yes      |
+
+### Example: default (push to AWS ECR and Docker Hub)
+
+TODO
+
 [configlet]: https://exercism.org/docs/building/configlet
 [configlet-lint]: https://exercism.org/docs/building/configlet/lint

--- a/README.md
+++ b/README.md
@@ -96,7 +96,94 @@ Which registry you want the built image to be pushed to can be enabled or disabl
 
 ### Example: default (push to AWS ECR and Docker Hub)
 
-TODO
+```yaml
+name: Build and Push Docker image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-push-image:
+    uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main
+    secrets:
+      AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}
+      AWS_REGION: ${{secrets.AWS_REGION}}
+      AWS_ECR_ACCESS_KEY_ID: ${{secrets.AWS_ECR_ACCESS_KEY_ID}}
+      AWS_ECR_SECRET_ACCESS_KEY: ${{secrets.AWS_ECR_SECRET_ACCESS_KEY}}
+      DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+      DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
+```
+
+### Example: only push to AWS ECR
+
+```yaml
+name: Build and Push Docker image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-push-image:
+    uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main
+    with:
+      docker_hub: false
+    secrets:
+      AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}
+      AWS_REGION: ${{secrets.AWS_REGION}}
+      AWS_ECR_ACCESS_KEY_ID: ${{secrets.AWS_ECR_ACCESS_KEY_ID}}
+      AWS_ECR_SECRET_ACCESS_KEY: ${{secrets.AWS_ECR_SECRET_ACCESS_KEY}}
+      DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+      DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
+```
+
+### Example: only push to Docker Hub
+
+```yaml
+name: Build and Push Docker image
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-push-image:
+    uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main
+    with:
+      aws_ecr: false
+    secrets:
+      AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}
+      AWS_REGION: ${{secrets.AWS_REGION}}
+      AWS_ECR_ACCESS_KEY_ID: ${{secrets.AWS_ECR_ACCESS_KEY_ID}}
+      AWS_ECR_SECRET_ACCESS_KEY: ${{secrets.AWS_ECR_SECRET_ACCESS_KEY}}
+      DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+      DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
+```
 
 [configlet]: https://exercism.org/docs/building/configlet
 [configlet-lint]: https://exercism.org/docs/building/configlet/lint


### PR DESCRIPTION
This PRs adds a reusable `docker-build-push-image` workflow, which simplifies (and makes consistent) the Docker build and push workflow used in the tooling repos.

The reusable configlet work allows for build the tooling's Docker image and pushing it to:

1. AWS ECR: enabled by default
2. Docker Hub: enabled by default

Once this PR is merged, we can then send bulk PRs to all tooling repos to update their docker workflow to use this reusable workflow.
The best way to do this is to use the `org-wide-files` syncing.

An additional benefit of using a reusable workflow is to greatly cut down on the number of dependabot PRs being created.
Currently, the docker workflow used in tooling repos all receive dependabot updates, but once we've migrated to a workflow that uses this reusable workflow, we only have to update these dependencies here.

---

I've created a sample PR to show what using this reusable workflow would look like: https://github.com/exercism/fsharp-representer/runs/5393628678?check_suite_focus=true
