### PR TITLE
Add labels syncing reusable workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,20 @@
+name: Tools
+
+on:
+  workflow_call:
+
+permissions:
+  issues: write
+
+jobs:
+  sync-labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -204,5 +204,33 @@ jobs:
       DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
 ```
 
+## Reusable workflow: labels
+
+The `labels` reusable workflow can be used to sync the repository's labels via its `.github/labels.yml` file.
+
+### Example
+
+```yaml
+name: Tools
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 1 * * # First day of each month
+
+permissions:
+  issues: write
+
+jobs:
+  sync-labels:
+    uses: exercism/github-actions/.github/workflows/labels.yml@main
+```
+
 [configlet]: https://exercism.org/docs/building/configlet
 [configlet-lint]: https://exercism.org/docs/building/configlet/lint


### PR DESCRIPTION
This PR adds a reusable version of the sync-labels.yml workflow. I couldn't call it that, as there is the actual main sync-labels workflow itself in this repo, which is why I named the reusable workflow `labels.yml` (I'm open to naming suggestions).

I've had to toy with the permissions a bit, but the `issues: write` pemissions managed to get things working.

See https://github.com/ErikSchierboom/fsharp-analyzer/runs/5404242635?check_suite_focus=true for an example run