### PR TITLE
🤖 Add labels append file

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,0 +1,12 @@
+# ----------------------------------------------------------------------------------------- #
+# These are the repository-specific labels that augment the Exercise-wide labels defined in #
+# https://github.com/exercism/org-wide-files/blob/main/global-files/.github/labels.yml.     #
+# ----------------------------------------------------------------------------------------- #
+
+- name: "dependencies"
+  description: "Pull requests that update a dependency file"
+  color: "0366d6"
+
+- name: "github_actions"
+  description: "Pull requests that update GitHub Actions code"
+  color: "000000"

--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -6,7 +6,3 @@
 - name: "dependencies"
   description: "Pull requests that update a dependency file"
   color: "0366d6"
-
-- name: "github_actions"
-  description: "Pull requests that update GitHub Actions code"
-  color: "000000"


### PR DESCRIPTION
Add a .appends/.github/labels.yml file.

The `.appends/.github/labels.yml` file contains all the labels that are currently used in this repo.
The `.github/labels.yml` file will contain the full list of labels that this repo can use, which will be a combination of the `.appends/.github/labels.yml` file and a centrally-managed `labels.yml` file.
We'll automatically sync any changes, which allows us to guarantee that all the track repositories will have a pre-determined set of labels, augmented with any custom labels defined in the `.appends/.github/labels.yml` file.