### PR TITLE
Support passing in Docker build args

### DIFF
--- a/.github/workflows/docker-build-push-image.yml
+++ b/.github/workflows/docker-build-push-image.yml
@@ -49,9 +49,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
-        with:
-          # Never deploy from non-main branches
-          ref: main
+        # with:
+        #   # Never deploy from non-main branches
+        #   ref: main
 
       - name: Check if Dockerfile is present
         id: dockerfile-exists

--- a/.github/workflows/docker-build-push-image.yml
+++ b/.github/workflows/docker-build-push-image.yml
@@ -49,9 +49,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
-        # with:
-        #   # Never deploy from non-main branches
-        #   ref: main
+        with:
+          # Never deploy from non-main branches
+          ref: main
 
       - name: Check if Dockerfile is present
         id: dockerfile-exists

--- a/.github/workflows/docker-build-push-image.yml
+++ b/.github/workflows/docker-build-push-image.yml
@@ -32,6 +32,9 @@ on:
       DOCKERHUB_PASSWORD:
         description: "The password used to log into Docker Hub"
         required: true
+      DOCKER_BUILD_ARGS:
+        description: "Docker build arguments"
+        required: false
 
 permissions:
   contents: write
@@ -87,6 +90,7 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: ${{ secrets.DOCKER_BUILD_ARGS }}
 
       - name: Push to Docker Hub
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5

--- a/.github/workflows/docker-build-push-image.yml
+++ b/.github/workflows/docker-build-push-image.yml
@@ -104,6 +104,7 @@ jobs:
             ${{ github.event.repository.full_name }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: ${{ secrets.DOCKER_BUILD_ARGS }}
 
       - name: Push to AWS ECR
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
@@ -117,3 +118,4 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: ${{ secrets.DOCKER_BUILD_ARGS }}


### PR DESCRIPTION
This PR allows the caller to pass in additional Docker build arguments, which we need for any private test runners that have some secret they need passed into the Docker build to allow them to be built.

I've verified that this is backwards-compatible: https://github.com/exercism/fsharp-representer/actions/runs/3828077702/jobs/6513268812