### PR TITLE
fetch-configlet: use GITHUB_TOKEN

### DIFF
--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -9,6 +9,10 @@ curlopts=(
   --retry 3
 )
 
+if [[ -n "${GITHUB_TOKEN}" ]]; then
+  curlopts+=(--header "authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
 get_download_url() {
   # Returns the download URL of the latest configlet Linux release from the GitHub API
   local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'


### PR DESCRIPTION
The configlet check in a track repo would sometimes fail when downloading configlet. This was due to rate limiting. Make authenticated requests in order to make it less likely that we hit a limit.

Closes: #101

---

The `fetch-configlet` script in track repos has done this for a long time.