### PR TITLE
fetch-configlet: make authenticated requests

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -26,6 +26,10 @@ jobs:
 
       - name: Fetch configlet
         uses: exercism/github-actions/configlet-ci@main
+        # GITHUB_TOKEN is not set when we run the fetch script, because we're in
+        # a composite action. Set GH_TOKEN so that we can make authenticated requests.
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Run configlet lint
         run: configlet lint

--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 curlopts=(
   --silent
@@ -8,6 +8,13 @@ curlopts=(
   --location
   --retry 3
 )
+
+if [[ -n "${GH_TOKEN}" ]]; then
+  curlopts+=(--header "authorization: Bearer ${GH_TOKEN}")
+else
+  echo "The GH_TOKEN environment variable is not set" >&2
+  exit 1
+fi
 
 get_download_url() {
   # Returns the download URL of the latest configlet Linux release from the GitHub API


### PR DESCRIPTION
(Edited after discussion below):

The configlet CI check in a track repo would sometimes fail due to a rate limiting error. That happened because the check runs this repo's fetch-configlet script, which was making unauthenticated requests (for which the rate limit is low).

Make curl perform authenticated requests, which have a higher rate limit of [1000 requests per hour per repository][1]. The `GITHUB_TOKEN` environment variable is not set when the script is run, [because we're in a composite action][2]. So this commit sets `GH_TOKEN`, as advised by an [error that occurs when using `gh` in the same context without setting a token][3]:

```text
    gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
      env:
        GH_TOKEN: ${{ github.token }}
```

Note that the `fetch-configlet` script present in every track repo (and synced via `exercism/org-wide-files`) is designed for local use, but already uses `GITHUB_TOKEN` when available. For robust CI, we want to keep using a separate version in a non-track repo for now.

[1]: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
[2]: https://www.github.com/cli/cli/issues/6534
[3]: https://www.github.com/cli/cli/commit/fe485c14cc1b

Closes: #101

---

I think this works. I've tested with:

- https://github.com/ee7/exercism-nim/commit/31f084ef8949712673eda7d0aea6c39926fca511
- https://github.com/ee7/exercism-nim/actions/runs/3883336081/jobs/6624523492#step:3:17

But if we're happy to merge, we should immediately trigger a configlet job manually on a track, and revert the change in this repo if it fails.