### PR TITLE
fetch-configlet: use `gh`, not `curl`

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Fetch configlet
         uses: exercism/github-actions/configlet-ci@main
         # GITHUB_TOKEN is not set when we run the fetch script, because we're in
-        # a composite action. Set GH_TOKEN so that we can make authenticated requests.
+        # a composite action. Set GH_TOKEN so that `gh release download` can
+        # make authenticated requests (it fails otherwise).
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -1,28 +1,13 @@
 #!/bin/bash
 set -eo pipefail
 
-curlopts=(
-  --silent
-  --show-error
-  --fail
-  --location
-  --retry 3
-)
-
-if [[ -n "${GH_TOKEN}" ]]; then
-  curlopts+=(--header "authorization: Bearer ${GH_TOKEN}")
-else
+if [[ -z "${GH_TOKEN}" ]]; then
   echo "The GH_TOKEN environment variable is not set" >&2
   exit 1
 fi
 
-get_download_url() {
-  # Returns the download URL of the latest configlet Linux release from the GitHub API
-  local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'
-  local asset_name='configlet-linux-64bit.tgz'
-  curl "${curlopts[@]}" --header "Accept: application/vnd.github.v3+json" "${api_url}" |
-    jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
-}
-
-download_url="$(get_download_url)"
-curl "${curlopts[@]}" "${download_url}" | tar xz -C bin/
+name='configlet.tar.gz'
+gh -R exercism/configlet release download --output "${name}" \
+  --pattern 'configlet-linux-64bit.tgz'
+tar xzf "${name}" -C bin/
+rm "${name}"


### PR DESCRIPTION
This `fetch-configlet` script is designed solely for the GitHub Actions environment, where `gh` is always installed. So let's use `gh` for these reasons:

- Less code.

- `gh release download` only makes authenticated requests. So a successful download should give a stronger guarantee that a token was used correctly, and that requests are subject to the higher rate limit.

- The configlet release assets are transitioning to a new naming scheme that includes a version number, and it is slightly cleaner to match a pattern with `gh` than with `jq`.

Note that the `fetch-configlet` script in every track repo is designed for local usage, and cannot assume that `gh` is installed.