### PR TITLE
fetch-configlet: use new asset naming scheme

### DIFF
--- a/configlet-ci/fetch-configlet
+++ b/configlet-ci/fetch-configlet
@@ -8,6 +8,6 @@ fi
 
 name='configlet.tar.gz'
 gh -R exercism/configlet release download --output "${name}" \
-  --pattern 'configlet-linux-64bit.tgz'
+  --pattern 'configlet_*_linux_x86-64.tar.gz'
 tar xzf "${name}" -C bin/
 rm "${name}"


### PR DESCRIPTION
Reflect [the change in the configlet repo][1].

[1]: https://www.github.com/exercism/configlet/commit/57e6c5fdb3f3