### PR TITLE
fetch-configlet: Add missing `GH_TOKEN` env definition to example

### DIFF
--- a/configlet-ci/README.md
+++ b/configlet-ci/README.md
@@ -24,7 +24,12 @@ jobs:
 
     - name: Fetch configlet
       uses: exercism/github-actions/configlet-ci@main
-        
+      # GITHUB_TOKEN is not set when we run the fetch script, because we're in
+      # a composite action. Set GH_TOKEN so that `gh release download` can
+      # make authenticated requests (it fails otherwise).
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Configlet Linter
       run: configlet lint
 


### PR DESCRIPTION
The configlet-ci action is using authenticated requests now. This change adds the necessary environment variable definition to the example in the README.

See
- https://github.com/exercism/github-actions/pull/109 and
- https://github.com/exercism/github-actions/pull/107

for more context.