### PR TITLE
configlet-sync: only update Exercism-owned repos

### DIFF
--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   sync-docs-metadata:
     timeout-minutes: 10
-    if: ${{ inputs.sync_docs }}
+    if: github.repository_owner == 'exercism' && inputs.sync_docs
     runs-on: ubuntu-24.04
 
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   check-test-sync:
     timeout-minutes: 10
-    if: ${{ inputs.sync_tests }}
+    if: github.repository_owner == 'exercism' && inputs.sync_tests
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
For reference: http://forum.exercism.org/t/automating-syncing-with-github-actions-final-testing-going-on-for-java-track-open-to-more-tracks/17807/43